### PR TITLE
Speed Improvements

### DIFF
--- a/DistanceScraper/DALs/LeaderboardEntryDAL.cs
+++ b/DistanceScraper/DALs/LeaderboardEntryDAL.cs
@@ -2,6 +2,7 @@
 using SteamKit2;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -49,22 +50,9 @@ namespace DistanceScraper.DALs
 				return;
 			}
 
-			// Fill the user cache if necessary
-			var steamIDs = new List<SteamID>();
-			foreach (var newEntry in newEntries)
+			if (Settings.Verbose)
 			{
-				var name = handlers.Friends.GetFriendPersonaName(newEntry.SteamID);
-				if (string.IsNullOrEmpty(name))
-				{
-					steamIDs.Add(newEntry.SteamID);
-				}
-			}
-			await scraper.RequestUserInfo(steamIDs);
-
-			foreach (var newEntry in newEntries)
-			{
-				var name = handlers.Friends.GetFriendPersonaName(newEntry.SteamID);
-				Utils.WriteLine($"New time: {name} set their first time on {leaderboard.LevelName}: {newEntry.Score / 1000.0:0.000}s with a rank of {newEntry.GlobalRank}!");
+				await Utils.LogNewLeaderboardEntry(leaderboard, newEntries, handlers, scraper);
 			}
 
 			var sqlSB = new StringBuilder("INSERT INTO LeaderboardEntries (LeaderboardID, Milliseconds, SteamID, FirstSeenTimeUTC, UpdatedTimeUTC) VALUES");

--- a/DistanceScraper/DALs/LeaderboardEntryDAL.cs
+++ b/DistanceScraper/DALs/LeaderboardEntryDAL.cs
@@ -77,19 +77,27 @@ namespace DistanceScraper.DALs
 			var command = new MySqlCommand(sql, Connection);
 			await command.ExecuteNonQueryAsync();
 			Connection.Close();
+			Utils.WriteLine($"({leaderboard.ID}){leaderboard.LevelName}: Added {newEntries.Count} new leaderboard entries to the database");
 		}
 
-		public async Task UpdateLeaderboardEntries(Dictionary<ulong, LeaderboardEntry> existingEntries, List<SteamUserStats.LeaderboardEntriesCallback.LeaderboardEntry> updatedEntries)
+		public async Task UpdateLeaderboardEntries(Leaderboard leaderboard, Dictionary<ulong, LeaderboardEntry> existingEntries, List<SteamUserStats.LeaderboardEntriesCallback.LeaderboardEntry> updatedEntries)
 		{
-			Connection.Open();
+			if (existingEntries.Count == 0 || updatedEntries.Count == 0)
+			{
+				return;
+			}
+
 			foreach (var updatedEntry in updatedEntries)
 			{
+				Connection.Open();
 				var existingEntry = existingEntries[updatedEntry.SteamID.ConvertToUInt64()];
 				var sql = $"UPDATE LeaderboardEntries SET Milliseconds = {updatedEntry.Score}, UpdatedTimeUTC = {DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()} WHERE ID = {existingEntry.ID}";
 				var command = new MySqlCommand(sql, Connection);
 				await command.ExecuteNonQueryAsync();
+				Connection.Close();
 			}
-			Connection.Close();
+
+			Utils.WriteLine($"({leaderboard.ID}){leaderboard.LevelName}: Updated {updatedEntries.Count} leaderboard entry records");
 		}
 	}
 }

--- a/DistanceScraper/DALs/LeaderboardEntryHistoryDAL.cs
+++ b/DistanceScraper/DALs/LeaderboardEntryHistoryDAL.cs
@@ -56,6 +56,8 @@ namespace DistanceScraper.DALs
 			var historyInsertsCommand = new MySqlCommand(historyInsertsSQL, Connection);
 			await historyInsertsCommand.ExecuteNonQueryAsync();
 			Connection.Close();
+
+			Utils.WriteLine($"({leaderboard.ID}){leaderboard.LevelName}: Saved leaderboard entry history for {updatedEntries.Count} improvements");
 		}
 	}
 }

--- a/DistanceScraper/DALs/PlayerDAL.cs
+++ b/DistanceScraper/DALs/PlayerDAL.cs
@@ -2,6 +2,8 @@
 using SteamKit2;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace DistanceScraper.DALs
@@ -15,17 +17,17 @@ namespace DistanceScraper.DALs
 			Connection = new MySqlConnection(Settings.ConnectionString);
 		}
 
-		public async Task<Player> GetPlayer(ulong steamID)
+		public async Task<Dictionary<ulong, Player>> GetPlayers(List<ulong> steamIDs)
 		{
 			Connection.Open();
-			var sql = $"SELECT ID, SteamID, Name FROM Players WHERE SteamID = {steamID}";
+			var sql = $"SELECT ID, SteamID, Name FROM Players WHERE SteamID IN ({string.Join(",", steamIDs)})";
 			var command = new MySqlCommand(sql, Connection);
 			var reader = await command.ExecuteReaderAsync();
 
-			Player player = null;
+			Dictionary<ulong, Player> players = new Dictionary<ulong, Player>();
 			while (reader.Read())
 			{
-				player = new Player()
+				players[reader.GetUInt64(1)] = new Player()
 				{
 					ID = reader.GetUInt32(0),
 					SteamID = reader.GetUInt64(1),
@@ -35,31 +37,75 @@ namespace DistanceScraper.DALs
 			reader.Close();
 			Connection.Close();
 
-			return player;
+			return players;
 		}
 		
 		public async Task AddPlayersFromEntries(List<SteamUserStats.LeaderboardEntriesCallback.LeaderboardEntry> newEntries, Handlers handlers, BaseScraper scraper)
 		{
-			foreach (var entry in newEntries)
+			if (newEntries.Count == 0)
 			{
-				var existingUser = await GetPlayer(entry.SteamID.ConvertToUInt64());
-				if (existingUser == null)
+				return;
+			}
+
+			// Get players from the DB and determine which SteamIDs will need to be added
+			var existingLookupBatches = newEntries.Chunk(100);
+			var playersToAdd = new List<SteamID>();
+			foreach (var batch in existingLookupBatches)
+			{
+				var existingUsers = await GetPlayers(batch.Select(x => x.SteamID.ConvertToUInt64()).ToList());
+				foreach (var entry in batch)
 				{
-					await scraper.RequestUserInfo(entry.SteamID);
-					var name = handlers.Friends.GetFriendPersonaName(entry.SteamID);
-					Connection.Open();
-
-					var sql = "INSERT INTO Players(SteamID, Name, FirstSeenTimeUTC) VALUES";
-					sql += $"({entry.SteamID.ConvertToUInt64()},@userName,{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()})";
-					Utils.WriteLine($"Adding {entry.SteamID.ConvertToUInt64()}: {name} to the players table");
-
-					var command = new MySqlCommand(sql, Connection);
-					command.Parameters.AddWithValue("@userName", name);
-					await command.ExecuteNonQueryAsync();
-
-					Connection.Close();
+					if (!existingUsers.ContainsKey(entry.SteamID.ConvertToUInt64()))
+					{
+						playersToAdd.Add(entry.SteamID);
+					}
 				}
 			}
+
+			// Skip the rest of this if there are no new players
+			if (playersToAdd.Count == 0)
+			{
+				return;
+			}
+
+			// Get steam names and cache them
+			var newPlayerBatches = playersToAdd.Chunk(100);
+			foreach (var batch in newPlayerBatches)
+			{
+				await scraper.RequestUserInfo(batch.ToList());
+			}
+
+			// Add new players to the database
+			// Build the string that will become the query
+			Connection.Open();
+			var sqlSB = new StringBuilder("INSERT INTO Players(SteamID, Name, FirstSeenTimeUTC) VALUES");
+			var i = 0;
+			foreach (var newPlayer in playersToAdd)
+			{
+				sqlSB.Append($"({newPlayer.ConvertToUInt64()},@userName{i},{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}),");
+				i++;
+			}
+			sqlSB.Remove(sqlSB.Length - 1, 1); // Remove last comma
+
+			// Create the sql query
+			var command = new MySqlCommand(sqlSB.ToString(), Connection);
+
+			// Add parameter values for player names
+			i = 0;
+			foreach (var newPlayer in playersToAdd)
+			{
+				var name = handlers.Friends.GetFriendPersonaName(newPlayer);
+				if (Settings.Verbose)
+				{
+					Utils.WriteLine($"Adding {newPlayer.ConvertToUInt64()}: {name} to the players table");
+				}
+				command.Parameters.AddWithValue($"@userName{i}", name);
+				i++;
+			}
+
+			await command.ExecuteNonQueryAsync();
+			Connection.Close();
+			Utils.WriteLine($"Added {playersToAdd.Count} new players to the database");
 		}
 	}
 }

--- a/DistanceScraper/Program.cs
+++ b/DistanceScraper/Program.cs
@@ -32,8 +32,22 @@ namespace DistanceScraper
 				{
 					while (true)
 					{
+						if (Settings.Verbose)
+						{
+							Utils.WriteLine("Scraping Leaderboards");
+						}
 						await scraper.ScrapeLeaderboards();
+						
+						if (Settings.Verbose)
+						{
+							Utils.WriteLine("Scraping Official Leaderboards");
+						}
 						await scraper.ScrapeOfficialLeaderboardEntries();
+						
+						if (Settings.Verbose)
+						{
+							Utils.WriteLine("Scraping Unofficial Leaderboards");
+						}
 						await scraper.ScrapeUnofficialLeaderboardEntries();
 					}
 				}

--- a/DistanceScraper/Scrapers/LeaderboardScraper.cs
+++ b/DistanceScraper/Scrapers/LeaderboardScraper.cs
@@ -45,7 +45,6 @@ namespace DistanceScraper
 		// Scrapes the leaderboard entries for the official maps
 		public async Task ScrapeOfficialLeaderboardEntries()
 		{
-			//Utils.WriteLine("Retrieving official sprint leaderboards from DB");
 			var leaderboards = await LeaderboardDAL.GetOfficialSprintLeaderboards();
 			await ScrapeLeaderboardEntries(leaderboards);
 		}

--- a/DistanceScraper/Scrapers/LeaderboardScraper.cs
+++ b/DistanceScraper/Scrapers/LeaderboardScraper.cs
@@ -85,7 +85,7 @@ namespace DistanceScraper
 				await PlayerDAL.AddPlayersFromEntries(newEntries, Handlers, this);
 				await LeaderboardEntryDAL.AddLeaderboardEntries(leaderboard, newEntries, Handlers, this);
 				await LeaderboardEntryHistoryDAL.AddLeaderboardEntryHistory(leaderboard, existingEntries, entriesToUpdate, Handlers, this);
-				await LeaderboardEntryDAL.UpdateLeaderboardEntries(existingEntries, entriesToUpdate);
+				await LeaderboardEntryDAL.UpdateLeaderboardEntries(leaderboard, existingEntries, entriesToUpdate);
 			}
 		}
 	}

--- a/DistanceScraper/Settings.cs
+++ b/DistanceScraper/Settings.cs
@@ -5,5 +5,6 @@
 		public static string ConnectionString { get; set; }
 		public static string Username { get; set; }
 		public static string Password { get; set; }
+		public static bool Verbose { get; set; } = false;
 	}
 }


### PR DESCRIPTION
The focus of these changes was to decrease the time it takes to scrape individual leaderboards. This is done through a few major improvements:

 - A verbose logging setting has been added to allow for different levels of logging (detailed and slower, simple and fast)
 - Player info is not retrieved unless necessary or needed for verbose logging
 - Player info is retrieved in batches instead of individually
 - Leaderboard entries are inserted in batches instead of individually